### PR TITLE
Constraining hatchling to prevent incompatible builds with Poetry v1.8.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = ["requests~=2.26"]
 homepage = "https://github.com/vannevar-labs/pyjot"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.32"]
 build-backend = "hatchling.build"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Hatchling recently released `v1.32.0` which includes build metadata version `2.5`. Unfortunately, version `2.4` is the latest version that remains compatible with poetry version `<2.0.0`. All `service-kit-py` repos require `poetry<2.0.0` due to using `--no-update` flags on the `poetry lock` and `poetry update` commands. Therefore, to ensure `pyjot` remains compatible with `service-kit-py` we need to constrain the hatchling build to be `<1.32.0`.

This PR adds that one line change.